### PR TITLE
Uncomment lang dependency to enable compatibility with all Jetbrains IDEs

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -20,11 +20,8 @@
   <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description -->
   <idea-version since-build="172.0"/>
 
-  <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html
-       on how to target different products -->
-  <!-- uncomment to enable plugin in all products
   <depends>com.intellij.modules.lang</depends>
-  -->
+
   <extensions defaultExtensionNs="com.intellij">
     <lang.parserDefinition language="Jsonnet" implementationClass="com.jsonnetplugin.JsonnetParserDefinition"/>
     <lang.syntaxHighlighterFactory language="Jsonnet" implementationClass="com.jsonnetplugin.JsonnetSyntaxHighlighterFactory"/>


### PR DESCRIPTION
This is working on PhpStorm, the plugin is recognized and language highlight is ok.
There's an issue with autocomplete and path completion on import that don't work well, but unfortunately I'm not really a Java dev so I'm unable to fix them at the moment.
If you need my support on testing on PhpStorm I'll be glad to help.