### PR TITLE
Support libsonnet file extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 IntelliJ Jsonnet
 -----------------
-This plugin teaches IntelliJ how to understand the .jsonnet and .jsonnet.TEMPLATE files. It includes the following features.
+This plugin teaches IntelliJ how to understand `.jsonnet`, `.jsonnet.TEMPLATE`, and `.libsonnet` files. It includes the following features:
 
 - Syntax Highlighting
 - Autocomplete for imported files, local variables

--- a/src/main/java/com/jsonnetplugin/JsonnetFileType.java
+++ b/src/main/java/com/jsonnetplugin/JsonnetFileType.java
@@ -27,7 +27,6 @@ public class JsonnetFileType extends LanguageFileType {
     @NotNull
     @Override
     public String getDefaultExtension() {
-        // TODO: .TEMPLATE files???
         return "jsonnet";
     }
 

--- a/src/main/java/com/jsonnetplugin/JsonnetFileTypeFactory.java
+++ b/src/main/java/com/jsonnetplugin/JsonnetFileTypeFactory.java
@@ -6,34 +6,6 @@ import org.jetbrains.annotations.NotNull;
 public class JsonnetFileTypeFactory extends FileTypeFactory {
     @Override
     public void createFileTypes(@NotNull FileTypeConsumer fileTypeConsumer) {
-        fileTypeConsumer.consume(
-                JsonnetFileType.INSTANCE,
-                new FileNameMatcher(){
-
-                    @Override
-                    public boolean accept(@NotNull String fileName) {
-                        return fileName.endsWith(".jsonnet");
-                    }
-
-                    @NotNull
-                    @Override
-                    public String getPresentableString() {
-                        return ".jsonnet";
-                    }
-                },
-                new FileNameMatcher(){
-
-                    @Override
-                    public boolean accept(@NotNull String fileName) {
-                        return fileName.endsWith(".jsonnet.TEMPLATE");
-                    }
-
-                    @NotNull
-                    @Override
-                    public String getPresentableString() {
-                        return ".jsonnet.TEMPLATE";
-                    }
-                }
-        );
+        fileTypeConsumer.consume(JsonnetFileType.INSTANCE, "jsonnet;libsonnet");
     }
 }

--- a/src/main/java/com/jsonnetplugin/JsonnetFileTypeFactory.java
+++ b/src/main/java/com/jsonnetplugin/JsonnetFileTypeFactory.java
@@ -6,6 +6,18 @@ import org.jetbrains.annotations.NotNull;
 public class JsonnetFileTypeFactory extends FileTypeFactory {
     @Override
     public void createFileTypes(@NotNull FileTypeConsumer fileTypeConsumer) {
-        fileTypeConsumer.consume(JsonnetFileType.INSTANCE, "jsonnet;libsonnet;jsonnet.TEMPLATE");
+        fileTypeConsumer.consume(JsonnetFileType.INSTANCE, "jsonnet;libsonnet");
+        fileTypeConsumer.consume(JsonnetFileType.INSTANCE, new FileNameMatcher() {
+            @Override
+            public boolean accept(@NotNull String fileName) {
+                return fileName.endsWith(".jsonnet.TEMPLATE");
+            }
+
+            @NotNull
+            @Override
+            public String getPresentableString() {
+                return ".jsonnet.TEMPLATE";
+            }
+        });
     }
 }

--- a/src/main/java/com/jsonnetplugin/JsonnetFileTypeFactory.java
+++ b/src/main/java/com/jsonnetplugin/JsonnetFileTypeFactory.java
@@ -6,6 +6,6 @@ import org.jetbrains.annotations.NotNull;
 public class JsonnetFileTypeFactory extends FileTypeFactory {
     @Override
     public void createFileTypes(@NotNull FileTypeConsumer fileTypeConsumer) {
-        fileTypeConsumer.consume(JsonnetFileType.INSTANCE, "jsonnet;libsonnet");
+        fileTypeConsumer.consume(JsonnetFileType.INSTANCE, "jsonnet;libsonnet;jsonnet.TEMPLATE");
     }
 }


### PR DESCRIPTION
Add "libsonnet" extension, which is the default template extension. I saw the way to do it in https://github.com/JetBrains/intellij-community/blob/master/plugins/yaml/src/org/jetbrains/yaml/YAMLFileTypeLoader.java
