### PR TITLE
Add recovery rules for JSON members

### DIFF
--- a/resources/com/jsonnetplugin/Jsonnet.bnf
+++ b/resources/com/jsonnetplugin/Jsonnet.bnf
@@ -64,9 +64,13 @@ obj ::= L_CURLY objinside? R_CURLY
 arr ::= L_BRACKET (expr (COMMA expr)* COMMA?)? R_BRACKET
 arrcomp ::= L_BRACKET expr COMMA? forspec compspec R_BRACKET
 objinside	::=	( objlocal COMMA )* L_BRACKET expr R_BRACKET COLON expr ( ( COMMA objlocal )* ( COMMA )? )? forspec compspec
-|	member ( COMMA member )* ( COMMA )?
+|	members
 
-member	::=	objlocal | assertStmt | field
+members ::= member ( COMMA member )* ( COMMA )? { recoverWhile = member_list_recover }
+private member_list_recover ::= !('}')
+
+member	::=	objlocal | assertStmt | field { recoverWhile = member_recover }
+private member_recover ::= !(',' | '}')
 
 field ::=	fieldname ( PLUS )? h expr
 |	fieldname L_PAREN ( params )? R_PAREN h expr

--- a/src/com/jsonnetplugin/JsonnetCompletionContributor.java
+++ b/src/com/jsonnetplugin/JsonnetCompletionContributor.java
@@ -49,7 +49,7 @@ public class JsonnetCompletionContributor extends CompletionContributor {
                                 }
                             }else if (element instanceof JsonnetObjinside) {
                                 List<JsonnetObjlocal> locals = ((JsonnetObjinside)element).getObjlocalList();
-                                for (JsonnetMember m: ((JsonnetObjinside)element).getMemberList()){
+                                for (JsonnetMember m: ((JsonnetObjinside)element).getMembers().getMemberList()){
                                     if (m.getObjlocal() != null){
                                         locals.add(m.getObjlocal());
                                     }

--- a/src/com/jsonnetplugin/JsonnetIdentifierReference.java
+++ b/src/com/jsonnetplugin/JsonnetIdentifierReference.java
@@ -44,7 +44,7 @@ public class JsonnetIdentifierReference extends PsiReferenceBase<PsiElement> imp
             }else if (element instanceof JsonnetObjinside) {
 
                 List<JsonnetObjlocal> locals = new ArrayList<>(((JsonnetObjinside)element).getObjlocalList());
-                for (JsonnetMember m: ((JsonnetObjinside)element).getMemberList()){
+                for (JsonnetMember m: ((JsonnetObjinside)element).getMembers().getMemberList()){
                     if (m.getObjlocal() != null){
                         locals.add(m.getObjlocal());
                     }


### PR DESCRIPTION
For some features such as auto completion, it's essential to add some sort of error recovery for JSON members. This PR introduces error recovery for JSON members that essentially bypasses incomplete fields until a `,` or `}` character is seen. The following screenshots show how these error recovery rules help auto completion.

In the following screenshot, the curser is after the `:` character and the user requests auto-complete:
<img width="320" alt="Screen Shot 2019-10-17 at 15 02 16" src="https://user-images.githubusercontent.com/50329522/67011470-f92f7e00-f0ef-11e9-822b-9a5576ed5606.png">

Current behavior:
<img width="320" alt="Screen Shot 2019-10-16 at 17 52 05" src="https://user-images.githubusercontent.com/50329522/67011621-44e22780-f0f0-11e9-93d8-f8157994eb76.png">

With error recovery:
<img width="456" alt="Screen Shot 2019-10-17 at 15 01 18" src="https://user-images.githubusercontent.com/50329522/67011639-4ca1cc00-f0f0-11e9-8ea3-d520c5f91da0.png">

As can be seen, with error recovery rules, the incomplete JSON field is bypassed until the `}` character. This results in a complete parse and allows the auto-completion to be able to do a full scope search.
