### PR TITLE
Implement support for resolving inherited properties

### DIFF
--- a/src/com/jsonnetplugin/JsonnetCompletionContributor.java
+++ b/src/com/jsonnetplugin/JsonnetCompletionContributor.java
@@ -14,7 +14,9 @@ import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class JsonnetCompletionContributor extends CompletionContributor {
     public JsonnetCompletionContributor() {
@@ -28,10 +30,13 @@ public class JsonnetCompletionContributor extends CompletionContributor {
 
                         while (element != null) {
                             if (element instanceof JsonnetSelect) {
-                                JsonnetObj resolved = resolveExprToObj((JsonnetExpr) element.getParent());
+                                JsonnetObjinside[] resolved = resolveExprToObj((JsonnetExpr) element.getParent());
                                 if (resolved != null) {
-                                    addMembersFromObject(resolved, resultSet);
+                                    for(JsonnetObjinside r: resolved){
+                                        addMembersFromObject(r, resultSet);
+                                    }
                                 }
+
                                 // Do not show suggestions from outer space if the element
                                 // before the dot can be resolved. We are only interested in the fields.
                                 return;
@@ -46,7 +51,9 @@ public class JsonnetCompletionContributor extends CompletionContributor {
                                     resultSet.addElement(LookupElementBuilder.create(i.getText()));
                                 }
                             } else if (element instanceof JsonnetObjinside) {
-                                List<JsonnetObjlocal> locals = ((JsonnetObjinside) element).getObjlocalList();
+
+                                List<JsonnetObjlocal> locals = new ArrayList<>(((JsonnetObjinside) element).getObjlocalList());
+
                                 JsonnetMembers members = ((JsonnetObjinside) element).getMembers();
                                 if (members != null) {
                                     for (JsonnetMember m: members.getMemberList()){
@@ -97,10 +104,10 @@ public class JsonnetCompletionContributor extends CompletionContributor {
         );
     }
 
-    private static void addMembersFromObject(JsonnetObj obj, CompletionResultSet resultSet) {
-        if (obj.getObjinside() == null || obj.getObjinside().getMembers() == null) return;
+    private static void addMembersFromObject(JsonnetObjinside obj, CompletionResultSet resultSet) {
+        if (obj == null || obj.getMembers() == null) return;
 
-        List<JsonnetMember> memberList = obj.getObjinside().getMembers().getMemberList();
+        List<JsonnetMember> memberList = obj.getMembers().getMemberList();
         for (JsonnetMember member : memberList) {
             if (member.getField() != null && member.getField().getFieldname().getIdentifier0() != null) {
                 String fieldName = member.getField().getFieldname().getIdentifier0().getText();
@@ -109,7 +116,7 @@ public class JsonnetCompletionContributor extends CompletionContributor {
         }
     }
 
-    private static JsonnetObj resolveExprToObj(JsonnetExpr expr) {
+    private static JsonnetObjinside[] resolveExprToObj(JsonnetExpr expr) {
         return resolveExprToObj(expr, new ArrayList<>());
     }
 
@@ -119,7 +126,7 @@ public class JsonnetCompletionContributor extends CompletionContributor {
      * To avoid infinite loops, we keep track of the list of expressions visited along this
      * call chain.git p
      */
-    private static JsonnetObj resolveExprToObj(JsonnetExpr expr, List<JsonnetExpr> visited) {
+    private static JsonnetObjinside[] resolveExprToObj(JsonnetExpr expr, List<JsonnetExpr> visited) {
         if (visited.contains(expr)) return null; // In the future we can give a warning here
         visited.add(expr);
 
@@ -138,22 +145,58 @@ public class JsonnetCompletionContributor extends CompletionContributor {
             visited.remove(expr);
         }
     }
-    static JsonnetObj resolveExprToObj(JsonnetExpr expr, List<JsonnetExpr> visited, List<JsonnetIdentifier0> selectList) {
+
+    static JsonnetObjinside[] resolveExprToObj(JsonnetExpr expr, List<JsonnetExpr> visited, List<JsonnetIdentifier0> selectList) {
         JsonnetExpr0 first = expr.getExpr0();
-        JsonnetObj curr = resolveExpr0ToObj(first, visited);
+        JsonnetObjinside[] curr = resolveExpr0ToObj(first, visited);
         for (JsonnetIdentifier0 select : selectList) {
             if (curr == null) return null;
 
-            JsonnetExpr fieldValue = getField(curr, select.getText());
-            if (fieldValue == null) return null;
+            List<JsonnetExpr> fieldValues = Arrays.stream(curr)
+                    .map(c -> getField(c, select.getText()))
+                    .filter(c -> c != null)
+                    .collect(Collectors.toList());
 
-            curr = resolveExprToObj(fieldValue, visited);
+            if (fieldValues.isEmpty()) return null;
+
+            List<JsonnetObjinside> resolvedList = fieldValues.stream()
+                    .map(f -> resolveExprToObj(f, visited))
+                    .filter(c -> c != null)
+                    .flatMap(c -> Arrays.stream(c))
+                    .collect(Collectors.toList());
+
+            curr = new JsonnetObjinside[resolvedList.size()];
+            resolvedList.toArray(curr);
         }
 
-        return curr;
+        List<JsonnetObjinside> extended = new java.util.ArrayList<>();
+
+        if (curr != null) {
+            for(JsonnetObjinside i: curr) {
+                extended.add(i);
+            }
+        }
+        for (JsonnetObjextend x: expr.getObjextendList()){
+            extended.add(x.getObjinside());
+        }
+        for (JsonnetBinsuffix x: expr.getBinsuffixList()){
+            JsonnetObjinside[] rhs = resolveExprToObj(x.getExpr(), visited);
+            if (rhs != null){
+                for(JsonnetObjinside i: rhs) {
+                    extended.add(i);
+                }
+            }
+        }
+
+        if (extended.size() == 0) return null;
+        else{
+            JsonnetObjinside[] res = new JsonnetObjinside[extended.size()];
+            extended.toArray(res);
+            return res;
+        }
     }
 
-    private static JsonnetObj resolveIdentifierToObj(JsonnetIdentifier0 id, List<JsonnetExpr> visited) {
+    private static JsonnetObjinside[] resolveIdentifierToObj(JsonnetIdentifier0 id, List<JsonnetExpr> visited) {
         if (id.getReference() == null) return null;
         PsiElement resolved = id.getReference().resolve();
         if (resolved instanceof JsonnetBind) {
@@ -163,10 +206,10 @@ public class JsonnetCompletionContributor extends CompletionContributor {
         return null;
     }
 
-    private static JsonnetExpr getField(JsonnetObj obj, String name) {
-        if (obj.getObjinside() == null || obj.getObjinside().getMembers() == null) return null;
+    private static JsonnetExpr getField(JsonnetObjinside obj, String name) {
+        if (obj == null || obj.getMembers() == null) return null;
 
-        List<JsonnetMember> memberList = obj.getObjinside().getMembers().getMemberList();
+        List<JsonnetMember> memberList = obj.getMembers().getMemberList();
         for (JsonnetMember member : memberList) {
             if (member.getField() != null && member.getField().getFieldname().getIdentifier0() != null) {
                 String fieldName = member.getField().getFieldname().getIdentifier0().getText();
@@ -178,21 +221,21 @@ public class JsonnetCompletionContributor extends CompletionContributor {
         return null;
     }
 
-    private static JsonnetObj resolveExpr0ToObj(JsonnetExpr0 expr0, List<JsonnetExpr> visited) {
+    private static JsonnetObjinside[] resolveExpr0ToObj(JsonnetExpr0 expr0, List<JsonnetExpr> visited) {
         if (expr0.getExpr() != null){
             return resolveExprToObj(expr0.getExpr(), visited);
         }
         if (expr0.getOuterlocal() != null){
             return resolveExprToObj(expr0.getOuterlocal().getExpr(), visited);
         }
-        if (expr0.getObj() != null){
-            return expr0.getObj();
+        if (expr0.getObj() != null && expr0.getObj().getObjinside() != null){
+            return new JsonnetObjinside[]{expr0.getObj().getObjinside()};
         }
         if (expr0.getText().equals("self")) {
-            return findSelfObject(expr0);
+            return new JsonnetObjinside[]{findSelfObject(expr0)};
         }
         if (expr0.getText().equals("$")) {
-            return findOuterObject(expr0);
+            return new JsonnetObjinside[]{findOuterObject(expr0)};
         }
         if (expr0.getImportop() != null) {
             JsonnetImportop importop = expr0.getImportop();
@@ -207,7 +250,7 @@ public class JsonnetCompletionContributor extends CompletionContributor {
             for(PsiElement c: file.getChildren()){
                 // Apparently children can be line comments and other unwanted rubbish
                 if (c instanceof JsonnetExpr) {
-                    JsonnetObj res = resolveExprToObj((JsonnetExpr) c, visited);
+                    JsonnetObjinside[] res = resolveExprToObj((JsonnetExpr) c, visited);
                     if (res != null) return res;
                 }
             }
@@ -219,15 +262,15 @@ public class JsonnetCompletionContributor extends CompletionContributor {
         return null;
     }
 
-    private static JsonnetObj findSelfObject(PsiElement elem) {
+    private static JsonnetObjinside findSelfObject(PsiElement elem) {
         PsiElement curr = elem;
         while (curr != null && !(curr instanceof JsonnetObj)) {
             curr = curr.getParent();
         }
-        return (JsonnetObj) curr;
+        return ((JsonnetObj) curr).getObjinside();
     }
 
-    private static JsonnetObj findOuterObject(PsiElement elem) {
+    private static JsonnetObjinside findOuterObject(PsiElement elem) {
         JsonnetObj obj = null;
         PsiElement curr = elem;
         while (curr != null) {
@@ -236,7 +279,7 @@ public class JsonnetCompletionContributor extends CompletionContributor {
             }
             curr = curr.getParent();
         }
-        return obj;
+        return (obj).getObjinside();
     }
 
     private static boolean checkIfImport(PsiElement position) {

--- a/src/com/jsonnetplugin/JsonnetCompletionContributor.java
+++ b/src/com/jsonnetplugin/JsonnetCompletionContributor.java
@@ -147,27 +147,7 @@ public class JsonnetCompletionContributor extends CompletionContributor {
     }
 
     static JsonnetObjinside[] resolveExprToObj(JsonnetExpr expr, List<JsonnetExpr> visited, List<JsonnetIdentifier0> selectList) {
-        JsonnetExpr0 first = expr.getExpr0();
-        JsonnetObjinside[] curr = resolveExpr0ToObj(first, visited);
-        for (JsonnetIdentifier0 select : selectList) {
-            if (curr == null) return null;
-
-            List<JsonnetExpr> fieldValues = Arrays.stream(curr)
-                    .map(c -> getField(c, select.getText()))
-                    .filter(c -> c != null)
-                    .collect(Collectors.toList());
-
-            if (fieldValues.isEmpty()) return null;
-
-            List<JsonnetObjinside> resolvedList = fieldValues.stream()
-                    .map(f -> resolveExprToObj(f, visited))
-                    .filter(c -> c != null)
-                    .flatMap(c -> Arrays.stream(c))
-                    .collect(Collectors.toList());
-
-            curr = new JsonnetObjinside[resolvedList.size()];
-            resolvedList.toArray(curr);
-        }
+        JsonnetObjinside[] curr = resolveExprLhsToObj(expr, visited, selectList);
 
         List<JsonnetObjinside> extended = new java.util.ArrayList<>();
 
@@ -194,6 +174,32 @@ public class JsonnetCompletionContributor extends CompletionContributor {
             extended.toArray(res);
             return res;
         }
+    }
+
+
+    static JsonnetObjinside[] resolveExprLhsToObj(JsonnetExpr expr, List<JsonnetExpr> visited, List<JsonnetIdentifier0> selectList) {
+        JsonnetExpr0 first = expr.getExpr0();
+        JsonnetObjinside[] curr = resolveExpr0ToObj(first, visited);
+        for (JsonnetIdentifier0 select : selectList) {
+            if (curr == null) return null;
+
+            List<JsonnetExpr> fieldValues = Arrays.stream(curr)
+                    .map(c -> getField(c, select.getText()))
+                    .filter(c -> c != null)
+                    .collect(Collectors.toList());
+
+            if (fieldValues.isEmpty()) return null;
+
+            List<JsonnetObjinside> resolvedList = fieldValues.stream()
+                    .map(f -> resolveExprToObj(f, visited))
+                    .filter(c -> c != null)
+                    .flatMap(c -> Arrays.stream(c))
+                    .collect(Collectors.toList());
+
+            curr = new JsonnetObjinside[resolvedList.size()];
+            resolvedList.toArray(curr);
+        }
+        return curr;
     }
 
     private static JsonnetObjinside[] resolveIdentifierToObj(JsonnetIdentifier0 id, List<JsonnetExpr> visited) {

--- a/src/com/jsonnetplugin/JsonnetIdentifierReference.java
+++ b/src/com/jsonnetplugin/JsonnetIdentifierReference.java
@@ -36,7 +36,7 @@ public class JsonnetIdentifierReference extends PsiReferenceBase<PsiElement> imp
                     selectList.add(select.getIdentifier0());
                 }
 
-                JsonnetObjinside[] objs = JsonnetCompletionContributor.resolveExprToObj(
+                JsonnetObjinside[] objs = JsonnetCompletionContributor.resolveExprLhsToObj(
                         (JsonnetExpr)element.getParent(),
                         new ArrayList<>(),
                         selectList


### PR DESCRIPTION
Fixes https://github.com/databricks/intellij-jsonnet/issues/14, https://github.com/databricks/intellij-jsonnet/issues/7, https://github.com/databricks/intellij-jsonnet/issues/13

First pass at implementing support for resolving inherited properties

To make this work, we modify the core recursive `resolveExprToObj` functions
to make them return a `JsonnetObjinside[]` instead of a `JsonnetObj`. This allows
us to resolve an expression to multiple source `JsonnetObj` literals, as well as
`JsonnetObjextend` literals which also have a `JsonnetObjinside` property.

`resolveExprToObj` grew two more sections, to aggregate the objects resolved from
any RHS extensions in `getObjextendList` and `getBinsuffixList`, and return them
together with any objects resolved from the LHS `getExpr0` expression. We rely on
the parser to ensure we chains of interleaved selects, extensions and binop suffixes
are parsed in the correct way.

The original `resolveExprToObj` has been split out into a `resolveExprLhsToObj` function, which is what we call from the `JsonnetIdentifierReference` since when auto-completing a `foo.bar` select chain we do not want to consider any `+`s or `{...}` extensions on the right

In `JsonnetIdentifierReference#multiResolve`, we handle this set of multiple
resolution results in two ways:

- If any one of the resolved `JsonnetObjinside` literals contains the property
  we want, we choose the right-most literal's version of it because inheritence
  occurs from left to right

- Otherwise, we simply return all the `JsonnetObjinside` literals, as a kind of
  "we tried, here's our best effort at finding where it came from" result to give
  the user starting points to investigate manually and figure out where the property
  they want is defined

`JsonnetCompletionContributor`, on the other hand, simply takes the list of results
from `resolveExprToObj` and provide all of them as possible completions.

This is able to correctly handle resolution of all the cases in the bottom row of
this snippet:

```
local a = {
  d: 0,
  local outer = self + {x: 1},
  b: { c: outer, c2: a.d + 1, d: a},
};

local e = a.b { d: 4 };
local e2 = (a { d: 4 }).b;

[e2.c.x, e.d, e.c.b.d, e.d]
```

Note that we cannot currently handle `self.foo` properties used in a RHS overriding
object, where the original `foo` is defined in some LHS base object. That would
require a more global inference than we are able to do here