### PR TITLE
support project relative imports

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "com.databricks"
-version = "1.2"
+version = "1.3"
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
* Best practice going forward is to import files relative to the project root.
* Include `bazel-bin` for generated files by default.